### PR TITLE
[W.I.P.] add postBuild, binder badge, and a bit more in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4278048.svg)](https://doi.org/10.5281/zenodo.4278048)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/gaelforget/Ocean-Plastic-Assimilator/gfdev01?urlpath=lab)
 
 # Ocean Plastic Assimilator - v0.1
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository contains the code of the Ocean Plastic Assimilator, a program to
 ## 1. Runtime requirements
 
 The required packages to perform a simulations are available in the `environment.yml` file.
-You can install them easily with `conda`. Please not you will need to add the conda-forge channels to your config:
+You can install them easily with `conda`. Please note that you will need to add the conda-forge channels to your config:
 
 ```
 conda config --add channels conda-forge

--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
+## 1.1 Get Started
+
+```
+conda env create -f environment.yml
+conda activate ocean-plastic-assimilator
+python examples/assimilate_double_gyre.py
+```
+
 ## 2. Data requirements
 
 See the [dedicated documentation file](docs/data_requirements.md).

--- a/docs/double_gyre.md
+++ b/docs/double_gyre.md
@@ -10,7 +10,7 @@ Use the following to generate two dispersion simulations with the flow field def
 
 All the required files are available using the following DOI: 
 
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4421869.svg)](https://doi.org/10.5281/zenodo.4421869)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4277840.svg)](https://doi.org/10.5281/zenodo.4277840)
 
 You can simply download the files and use them as input of the assimilator using the example available in the `examples/` folder.
 

--- a/postBuild
+++ b/postBuild
@@ -1,0 +1,2 @@
+wget https://zenodo.org/record/4426130/files/parts_double_gyre_ref_eps_0.25_A_0.1175_as_2.nc
+

--- a/postBuild
+++ b/postBuild
@@ -1,2 +1,5 @@
-wget https://zenodo.org/record/4426130/files/parts_double_gyre_ref_eps_0.25_A_0.1175_as_2.nc
+mkdir data
+wget https://zenodo.org/record/4426130/files/parts_double_gyre_ref_eps_0.25_A_0.1175_as_2.nc data/.
+wget https://zenodo.org/record/4426130/files/Ocean_Plastic_Assimilator_v0.1_outputs.zip
+unzip cean_Plastic_Assimilator_v0.1_outputs.zip
 

--- a/postBuild
+++ b/postBuild
@@ -1,5 +1,5 @@
 mkdir data
 wget https://zenodo.org/record/4426130/files/parts_double_gyre_ref_eps_0.25_A_0.1175_as_2.nc data/.
 wget https://zenodo.org/record/4426130/files/Ocean_Plastic_Assimilator_v0.1_outputs.zip
-unzip cean_Plastic_Assimilator_v0.1_outputs.zip
+unzip Ocean_Plastic_Assimilator_v0.1_outputs.zip
 


### PR DESCRIPTION
With included changes one can try things out on `mybinder.org`, for example @ 

https://mybinder.org/v2/gh/gaelforget/Ocean-Plastic-Assimilator/gfdev01?urlpath=lab

But aside from changes included in this PR, I get an error show below (both on cloud instance and local machine). 

Would it be easy to fix (either before merging this PR or afterwards) ? 

```
# To activate this environment, use
#
#     $ conda activate ocean-plastic-assimilator
#
# To deactivate an active environment, use
#
#     $ conda deactivate

jovyan@jupyter-gaelforget-2docea-2dtic-2dassimilator-2dn05689s9:~$ conda activate ocean-plastic-assimilator
(ocean-plastic-assimilator) jovyan@jupyter-gaelforget-2docea-2dtic-2dassimilator-2dn05689s9:~$ python examples/assimilate_double_gyre.py
Traceback (most recent call last):
  File "examples/assimilate_double_gyre.py", line 1, in <module>
    from src.run_assimilator import run_assimilator
ModuleNotFoundError: No module named 'src'
```

with this python version being used

```
Python 3.8.8 | packaged by conda-forge | (default, Feb 20 2021, 16:22:27) 
[GCC 9.3.0] on linux
```
